### PR TITLE
It is required to call the release profile for a release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
      <!-- maven-release-plugin -->
      <!-- we don't distribute this version of gatein thus we don't generate
      packages for the release - pkg-tomcat,pkg-jbossas profiles are removed -->
-     <arguments>-DskipTests</arguments>
+     <arguments>-DskipTests -Prelease</arguments>
      <pushChanges>false</pushChanges>
      <version.release.plugin>2.1</version.release.plugin>
 


### PR DESCRIPTION
It is required to call the release profile to be sure to publish additional binaries like ear, tomcat, .. used by thirdparties like platform.
